### PR TITLE
Removes unlisted files from collection metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ metalsmith.use(publish({
 
 ### Unlisted
 
-Removes the `collection` metadata, useful for publishing internally wihtout adding it to your posts lists or RSS feeds.
+Removes the `collection` metadata, useful for publishing internally wihtout adding it to your posts lists or RSS feeds. Use it after `collection` plugin.
 
 ```markdown
 ---

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,11 @@ function plugin(opts) {
 			}
 
 			if (pub === 'unlisted' && !opts.unlisted) {
+                                for (var col_name of files[file].collection) {
+                                        var col = metalsmith._metadata.collections[col_name]
+                                        var idx = col.findIndex(f => f.path == file)
+                                        delete col[idx] // remove the file from collections array
+                                }
 				delete files[file].collection;
 			}
 


### PR DESCRIPTION
Currently implementation just removes `files[file].collection`, which stores just names of collections this file in.

This PR looks in `metalsmith._metadata.collections` and removes unlisted files from there.